### PR TITLE
Specify absolute import semantics for Python 2.7

### DIFF
--- a/pybats/pytest.py
+++ b/pybats/pytest.py
@@ -1,5 +1,7 @@
 # vim: fileencoding=utf-8
 
+from __future__ import absolute_import
+
 from . import core
 import pytest
 


### PR DESCRIPTION
As reported in issue #4, tests are failing on Python2.7 versions
due to the wrong module being imported.