### PR TITLE
Add usedevelop=True to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist = py27,py33,py34,py35,py36,pypy,flake8
 
 [testenv]
+usedevelop = True
 deps = pytest
        pytest-cov
 commands = py.test {posargs:tests}


### PR DESCRIPTION
Coverage run under tox was having problems finding covered files.