### PR TITLE
Use coverage instead of pytest-cov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - pip install codecov
 
 script:
-  - tox -e $TOX_ENV -- tests/ --cov=pybats
+  - tox -e $TOX_ENV
 
 after_success:
   - codecov

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ envlist = py27,py33,py34,py35,py36,pypy,flake8
 [testenv]
 usedevelop = True
 deps = pytest
-       pytest-cov
-commands = py.test {posargs:tests}
+       coverage
+commands = coverage run --source pybats -m py.test {posargs:tests}
+	   coverage report
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
Fixes issue #10.

Since **coverage** works by installing a trace hook, any code that
was imported before **coverage** installs that hook is uncovered
regardless of true status. **Pybats** registers a setuptools
entry point for **pytest**, which means it gets loaded in the same
process that loads **pytest-cov**, which then loads **coverage**.

There's a race condition here: if **pybats** loads before **pytest-cov**,
all top-level module contents are "uncovered" by tests. If
**pytest-cov** loads first, all is well.

Just cut the Gordian Knot and use **coverage** directly.