### PR TITLE
Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ While deliberating on how to integrate the test states, the question of “why a
 ---
 
 1. [@sstephenson] is the original author of Bats, and the reference link points to the original repo accordingly. After a period of inactivity, the code was forked and development now continues at [bats-core/bats-core]. <small><a href='#a1' id='f1'>↩</a></small>
-1. ``erroutput``<small>[↩](#a2.1)</small> and ``errlines``<small>[↩](#a2.2)</small> are only populated if stderr is redirected; see [the docs][pybats-docs] for details.
 
 
 [@sstephenson]: https://github.com/sstephenson/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ def test_cli_unknown_option():
     assert re.match(r'(?i)Usage: democli', lines[-1])
 ~~~
 
+## Alternatives
+
+<dl>
+    <dt><a href='https://bitheap.org/cram'>cram</a></dt>
+    <dd>
+        <blockquote>a functional testing framework for command line applications based on Mercurial's unified test format</blockquote>
+        Worth taking a look at, especially for writing tests in a declarative style.
+    </dd>
+</dl>
+
 ## Author's note
 
 The original goal of this project was to run Bats tests as-written from within [pytest].

--- a/README.md
+++ b/README.md
@@ -1,92 +1,58 @@
-# pybats [![Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![Travis](https://img.shields.io/travis/ryanvolpe/pybats.svg?style=flat-square)](https://travis-ci.org/ryanvolpe/pybats) [![Codecov](https://img.shields.io/codecov/c/github/ryanvolpe/pybats.svg?style=flat-square)](https://codecov.io/gh/ryanvolpe/pybats)
+# pybats: simple command line tests
+[![Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![Travis](https://img.shields.io/travis/ryanvolpe/pybats.svg?style=flat-square)](https://travis-ci.org/ryanvolpe/pybats) [![Codecov](https://img.shields.io/codecov/c/github/ryanvolpe/pybats.svg?style=flat-square)](https://codecov.io/gh/ryanvolpe/pybats)
 
+###### **–»** Utility testing, inspired by [**Bats**][sstephenson/bats].<sup id='a1'>[\[1\]](#f1)</sup>
 
-Command line utility testing inspired by [**Bats**][sstephenson/bats]<sup id='a1'>[1](#f1)</sup>.
+---
 
-## Usage
+**Note** This readme is intended as a brief introduction, and assumes [pytest] as the test framework. Instructions to support other test frameworks are in the [documentation][pybats-docs].
 
-This readme is a brief introduction to pybats. More details may be found in the [documentation][pybats-docs].
+## Example
 
-### Pytest
-Upon installation, a plugin is registered for [pytest]. This plugin provides a fixture named ``pybats`` which can be used as below:
+**Command under test, and expected output:**
+<pre>
+<b>$ democli --xxx-unknown-option</b>
+Error: unknown option --xxx-unknown-option
+Usage: democli [OPTIONS] <command>
+</pre>
 
-~~~python
-def test_echo(pybats):
-    with pybats.command('echo', 'spam') as cmd:
-        assert cmd.status == 0
-        assert cmd.output == 'spam'
-~~~
-
-### Unittest, nose, *etc.*
-If you're not using [pytest], pybats should still work for you. You'll just need to initialize a ``Context`` object:
+**Using ``pybats``:**
 
 ~~~python
-from pybats import core
-
-def test_echo():
-    pybats = core.Context()
-    with pybats.command('echo', 'spam') as cmd:
-        assert cmd.status == 0
-        assert cmd.output == 'spam'
+def test_cli_unknown_option(pybats):
+    with pybats.command('democli', '--xxx-unknown-option') as cmd:
+        # ensure exit code was NOT 0
+        assert cmd.status != 0
+        # check that the first line of output is an error message
+        cmd.lines[0].assert_match(r'(?i)Error: unknown option')
+        # check that the error message includes the unknown option
+        cmd.lines[0].assert_search(r'\b---xxx-unknown-option\b')
+        # check that the last line of output is usage information
+        cmd.lines[-1].assert_match(r'(?i)^Usage: democli')
 ~~~
 
-## Comparison with Bats
-
-### Fixtures
-Description | Bats | pybats
------------ | ---- | ------
-Runs a *command* | ``run ...`` | ``with pybats.command(...) as cmd``
-Command exit code | ``$status`` | ``cmd.status``
-Interleaved stdout and stderr | ``$output`` | ``cmd.output``
-Array of lines of output | ``${lines[@]}`` | ``cmd.lines``
-Only stderr | — | ``cmd.erroutput``<sup id='a2.1'>[2](#f2)</sup>
-Array of lines of stderr | — | ``cmd.errlines``<sup id='a2.2'>[2](#f2)</sup>
-Set environment variable | ``VARIABLE=value`` | ``pybats.environment['VARIABLE'] = 'value'``
-Load file relative to root | ``load <path>`` | —
-Skip test | ``skip [message]`` | —
-
-### Example
-
-Let's use a few simple test cases to illustrate the differences between Bats and pybats:
-
-- Does ``echo 'test'``:
-  - print ``"test"``?
-  - exit ``0``?
-- Does ``util --help``:
-  - print at least one line of output?
-  - print a line that startswith ``"Usage:"``?
-  - exit ``0``?
-
-#### Bats
-
-~~~bash
-@test "test echo" {
-    run echo 'test'
-    [ "$status" -eq 0 ]
-    [ "$output" = "test" ]
-}
-
-@test "command with --help option" {
-    run util --help
-    [ "$status" -eq 0 ]
-    [ "${#lines[@]}" -ge 1 ]
-    [[ "${lines[0]}" =~ Usage: ]]
-}
-~~~
-
-#### pybats (using pytest fixtures)
+**Without ``pybats``:**
 
 ~~~python
-def test_echo(pybats):
-    with pybats.command('echo', 'test') as cmd:
-        assert cmd.status == 0
-        assert cmd.output == 'test'
+import re
+import subprocess
 
-def test_command_with_help_option(pybats):
-    with pybats.command('util', '--help') as cmd:
-        assert cmd.status == 0
-        assert len(cmd.lines) >= 1
-        assert cmd.lines[0].match(r'^Usage:')
+def test_cli_unknown_option():
+    proc = subprocess.Popen(
+        ['democli', '--xxx-unknown-option'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True)
+    stdout, stderr = proc.communicate()
+    # ensure exit code was NOT 0
+    assert proc.returncode != 0
+    # check that the first line of output is an error message
+    lines = stdout.split('\n')
+    assert re.match(r'(?i)Error: unknown option', lines[0])
+    # check that the error message includes the unknown option
+    assert re.search(r'\b--xxx-unknown-option\b', lines[0])
+    # check that the last line of output is usage information
+    assert re.match(r'(?i)Usage: democli', lines[-1])
 ~~~
 
 ## Author's note


### PR DESCRIPTION
Streamline the top-level README:
- remove direct Bats comparisons
- refactor example
  - include equivalent test without pybats
- added alternatives (just cram ATM)